### PR TITLE
included an output to expose EC2 meta data, specifically the EC2 id t…

### DIFF
--- a/copilot_build_aws/outputs.tf
+++ b/copilot_build_aws/outputs.tf
@@ -1,3 +1,8 @@
+output ec2-info {
+  value       = aws_instance.aviatrixcopilot.*
+  description = "EC2 instance info"
+}
+
 output private_ip {
   value       = aws_instance.aviatrixcopilot.*.private_ip
   description = "Private IP address of the Aviatrix Copilot"


### PR DESCRIPTION
**Motivation**
Exposing EC2 meta information via outputs to be referenced by correlated components (i.e.: ALB)

 