### PR TITLE
changing output of IP's to an instance in stead of a list

### DIFF
--- a/copilot_build_aws/outputs.tf
+++ b/copilot_build_aws/outputs.tf
@@ -1,9 +1,9 @@
 output private_ip {
-  value       = aws_instance.aviatrixcopilot.*.private_ip
+  value       = aws_instance.aviatrixcopilot.private_ip
   description = "Private IP address of the Aviatrix Copilot"
 }
 
 output public_ip {
-  value       = aws_eip.copilot_eip.*.public_ip
+  value       = aws_eip.copilot_eip.public_ip
   description = "Public IP address of the Aviatrix Copilot"
 }


### PR DESCRIPTION
In all modules except AWS, we output the public/private IP as a single object. In AWS we generate a list, by referencing a wildcard. This is inconsistent behavior, as well as unnecessary as the list only has a single entry.