### PR TITLE
AVX-21483: support ssh key content in Azure, GCP and OCI

### DIFF
--- a/copilot_build_aws/variables.tf
+++ b/copilot_build_aws/variables.tf
@@ -136,7 +136,7 @@ data "aws_ec2_instance_type_offering" "offering" {
 
   filter {
     name   = "instance-type"
-    values = [local.instance_type]
+    values = ["t2.micro", "t3.micro", local.instance_type]
   }
 
   filter {
@@ -145,6 +145,8 @@ data "aws_ec2_instance_type_offering" "offering" {
   }
 
   location_type = "availability-zone"
+
+  preferred_instance_types = [local.instance_type, "t3.micro", "t2.micro"]
 }
 
 locals {

--- a/copilot_build_azure/README.md
+++ b/copilot_build_azure/README.md
@@ -91,7 +91,7 @@ output "copilot_private_ip" {
 
 - **virtual_machine_admin_password**
 
-  Admin Password for the copilot virtual machine.
+  Admin Password for the copilot virtual machine. Required when **add_ssh_key** is false.
 
 - **virtual_machine_size**
 
@@ -109,7 +109,7 @@ output "copilot_private_ip" {
 
   OS disk size for the copilot virtual machine. The minimum size is 30G. Default: 30.
 
-> **NOTE:** If **add_ssh_key** is not set, no SSH key will be added to Copilot. If **use_existing_ssh_key** is set to false, an SSH key will be generated and added to Copilot. If **use_existing_ssh_key** is set to true, **ssh_public_key_file_path** is required.
+> **NOTE:** If **add_ssh_key** is not set, no SSH key will be added to Copilot. If **use_existing_ssh_key** is set to false, an SSH key will be generated and added to Copilot. If **use_existing_ssh_key** is set to true, either **ssh_public_key_file_path** or **ssh_public_key_file_content** must be configured.
 
 - **add_ssh_key**
 
@@ -122,6 +122,10 @@ output "copilot_private_ip" {
 - **ssh_public_key_file_path**
 
   File path to the SSH public key. If not set, defaults to "".
+
+- **ssh_public_key_file_content**
+
+  File content of the SSH public key. If not set, defaults to "".
 
 - **default_data_disk_size**
 

--- a/copilot_build_azure/main.tf
+++ b/copilot_build_azure/main.tf
@@ -106,9 +106,7 @@ resource "azurerm_linux_virtual_machine" "aviatrix_copilot_vm" {
 resource "azurerm_linux_virtual_machine" "aviatrix_copilot_vm_ssh" {
   count                           = var.add_ssh_key ? 1 : 0
   admin_username                  = var.virtual_machine_admin_username
-  admin_password                  = var.virtual_machine_admin_password
   name                            = "${var.copilot_name}-vm"
-  disable_password_authentication = false
   location                        = var.location
   network_interface_ids           = [azurerm_network_interface.aviatrix_copilot_nic.id]
   resource_group_name             = var.use_existing_vnet == false ? azurerm_resource_group.aviatrix_copilot_rg[0].name : var.resource_group_name

--- a/copilot_build_azure/variables.tf
+++ b/copilot_build_azure/variables.tf
@@ -47,6 +47,7 @@ variable "virtual_machine_admin_username" {
 variable "virtual_machine_admin_password" {
   type        = string
   description = "Admin Password for the copilot virtual machine"
+  default     = ""
 }
 
 variable "virtual_machine_size" {
@@ -70,6 +71,12 @@ variable "use_existing_ssh_key" {
 variable "ssh_public_key_file_path" {
   type        = string
   description = "File path to the SSH public key"
+  default     = ""
+}
+
+variable "ssh_public_key_file_content" {
+  type        = string
+  description = "File content of the SSH public key"
   default     = ""
 }
 
@@ -114,5 +121,5 @@ variable "additional_disks" {
 }
 
 locals {
-  ssh_key = var.add_ssh_key ? (var.use_existing_ssh_key == false ? tls_private_key.key_pair_material[0].public_key_openssh : file(var.ssh_public_key_file_path)) : ""
+  ssh_key = var.add_ssh_key ? (var.use_existing_ssh_key == false ? tls_private_key.key_pair_material[0].public_key_openssh : (var.ssh_public_key_file_path != "" ? file(var.ssh_public_key_file_path) : var.ssh_public_key_file_content)) : ""
 }

--- a/copilot_build_gcp/README.md
+++ b/copilot_build_gcp/README.md
@@ -85,7 +85,7 @@ output "copilot_private_ip" {
 
   Map of allowed incoming CIDRs. Please set protocol(string), port(string) and cidrs(set of strings) in each map element. Please see the example code above for example.
 
-> **NOTE:** If **ssh_user** is not set, no SSH key will be added to Copilot. If **use_existing_ssh_key** is set to false, an SSH key will be generated and added to Copilot. If **use_existing_ssh_key** is set to true, **ssh_public_key_file_path** is required.
+> **NOTE:** If **ssh_user** is not set, no SSH key will be added to Copilot. If **use_existing_ssh_key** is set to false, an SSH key will be generated and added to Copilot. If **use_existing_ssh_key** is set to true, either **ssh_public_key_file_path** or **ssh_public_key_file_content** must be configured.
 
 - **ssh_user**
 
@@ -98,6 +98,10 @@ output "copilot_private_ip" {
 - **ssh_public_key_file_path**
 
   File path to the SSH public key. If not set, defaults to "".
+
+- **ssh_public_key_file_content**
+
+  File content of the SSH public key. If not set, defaults to "".
 
 - **default_data_disk_size**
 

--- a/copilot_build_gcp/variables.tf
+++ b/copilot_build_gcp/variables.tf
@@ -72,6 +72,12 @@ variable "ssh_public_key_file_path" {
   default     = ""
 }
 
+variable "ssh_public_key_file_content" {
+  type        = string
+  description = "File content of the SSH public key"
+  default     = ""
+}
+
 variable "default_data_disk_size" {
   default     = 0
   type        = number
@@ -96,5 +102,5 @@ variable "boot_disk_size" {
 }
 
 locals {
-  ssh_key = var.ssh_user == "" ? "" : (var.use_existing_ssh_key == false ? "${var.ssh_user}:${tls_private_key.key_pair_material[0].public_key_openssh}" : "${var.ssh_user}:${file(var.ssh_public_key_file_path)}")
+  ssh_key = var.ssh_user == "" ? "" : (var.use_existing_ssh_key == false ? "${var.ssh_user}:${tls_private_key.key_pair_material[0].public_key_openssh}" : (var.ssh_public_key_file_path != "" ? "${var.ssh_user}:${file(var.ssh_public_key_file_path)}" : "${var.ssh_user}:${var.ssh_public_key_file_content}"))
 }

--- a/copilot_build_oci/README.md
+++ b/copilot_build_oci/README.md
@@ -141,7 +141,7 @@ value = module.copilot_build_oci.private_ip
 
   Copilot version. Default: "1.6.1".
 
-> **NOTE:** If **use_existing_ssh_key** is set to false, new keys will be generated. If **use_existing_keypair** is set to true, **ssh_public_key_file_path** is required.
+> **NOTE:** If **use_existing_ssh_key** is set to false, new keys will be generated. If **use_existing_keypair** is set to true, either **ssh_public_key_file_path** or **ssh_public_key_file_content** must be configured.
 
 - **use_existing_ssh_key**
 
@@ -150,6 +150,10 @@ value = module.copilot_build_oci.private_ip
 - **ssh_public_key_file_path**
 
   File path to the SSH public key. If not set, defaults to "".
+
+- **ssh_public_key_file_content**
+
+  File content of the SSH public key. If not set, defaults to "".
 
 > **NOTE:** Please make sure the additional volumes and the copilot vm are in the same availability domain.
 

--- a/copilot_build_oci/variables.tf
+++ b/copilot_build_oci/variables.tf
@@ -144,6 +144,12 @@ variable "ssh_public_key_file_path" {
   default     = ""
 }
 
+variable "ssh_public_key_file_content" {
+  type        = string
+  description = "File content of the SSH public key"
+  default     = ""
+}
+
 variable "default_data_volume_size" {
   default     = 0
   type        = number
@@ -159,5 +165,5 @@ variable "additional_volumes" {
 }
 
 locals {
-  ssh_key = var.use_existing_ssh_key == false ? tls_private_key.key_pair_material[0].public_key_openssh : file(var.ssh_public_key_file_path)
+  ssh_key = var.use_existing_ssh_key == false ? tls_private_key.key_pair_material[0].public_key_openssh : (var.ssh_public_key_file_path != "" ? file(var.ssh_public_key_file_path) : var.ssh_public_key_file_content)
 }


### PR DESCRIPTION
Also added a workaround for the bug where AZ can't be found for some newer instance types. It looks like a bug in AWS provider.