### PR TITLE
Use POSIX compatible commands in script waiting for copilot

### DIFF
--- a/copilot_build_aws/main.tf
+++ b/copilot_build_aws/main.tf
@@ -172,7 +172,6 @@ resource "null_resource" "wait_for_copilot" {
   provisioner "local-exec" {
     when    = create
     command = <<EOF
-#!/bin/bash
 echo "Waiting for Copilot..."
 count=0
 until [ "$(curl -ks https://${try(aws_eip.copilot_eip[0].public_ip, "")}/api/info/updateStatus | jq -r '.status')" = "finished" ]

--- a/copilot_build_aws/main.tf
+++ b/copilot_build_aws/main.tf
@@ -178,8 +178,8 @@ count=0
 until [ "$(curl -ks https://${try(aws_eip.copilot_eip[0].public_ip, "")}/api/info/updateStatus | jq -r '.status')" = "finished" ]
 do
   sleep 10
-  ((count++))
-  if [[ $count -eq 60 ]]; then
+  count=$((count+1))
+  if [ $count -eq 60 ]; then
     break
   fi
 done


### PR DESCRIPTION
Fix for issue #49 

Fix to use more portable commands since `local-exec` provisioner falls back to default shell if `interpreter` not specified, and not all systems have bash.