### PR TITLE
fix: remove deprecated vpc argument from aws_eip resource

### DIFF
--- a/copilot_build_aws/main.tf
+++ b/copilot_build_aws/main.tf
@@ -124,7 +124,6 @@ resource "aws_security_group" "AviatrixCopilotSecurityGroup" {
 
 resource "aws_eip" "copilot_eip" {
   count = var.private_mode == false ? 1 : 0
-  vpc   = true
   tags  = local.common_tags
 }
 

--- a/copilot_build_aws/main.tf
+++ b/copilot_build_aws/main.tf
@@ -124,6 +124,7 @@ resource "aws_security_group" "AviatrixCopilotSecurityGroup" {
 
 resource "aws_eip" "copilot_eip" {
   count = var.private_mode == false ? 1 : 0
+  domain = "vpc"
   tags  = local.common_tags
 }
 


### PR DESCRIPTION
- Removed unsupported 'vpc = true' argument from aws_eip resource
- This fixes Terraform validation error: 'An argument named vpc is not expected here'
- The vpc argument has been deprecated in favor of domain argument in newer AWS provider versions

Original Failed Run: https://github.com/AviatrixDev/cloudn/actions/runs/17771398109/job/50509880839?pr=49004#logs

When running on local
`gadheyan@Gadheyan-QA-Engineer /home/gadheyan/AviatrixDev/end2end/cloudn                                            master
⚡ cd /home/gadheyan/AviatrixDev/end2end/cloudn/test-scripts/end-to-end/vendor/controller && terraform validate
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/aviatrix_controller_aws/main.tf line 52, in module "aviatrix_controller_initialize":
│   52:   aws_region                  = var.aws_region == "" ? data.aws_region.current.name : var.aws_region
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│
│ (and 15 more similar warnings elsewhere)
╵
╷
│ Error: Unsupported argument
│
│   on .terraform/modules/copilot_build_aws/copilot_build_aws/main.tf line 127, in resource "aws_eip" "copilot_eip":
│  127:   vpc   = true
│
│ An argument named "vpc" is not expected here.
╵`

After the changes in the PR

`gadheyan@Gadheyan-QA-Engineer /home/gadheyan/AviatrixDev/end2end/cloudn/test-scripts/end-to-end/vendor/controller  master
⚡ cd /home/gadheyan/AviatrixDev/end2end/cloudn/test-scripts/end-to-end/vendor/controller && terraform validate
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/aviatrix_controller_aws/main.tf line 52, in module "aviatrix_controller_initialize":
│   52:   aws_region                  = var.aws_region == "" ? data.aws_region.current.name : var.aws_region
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│
│ (and 15 more similar warnings elsewhere)
╵
Success! The configuration is valid, but there were some validation warnings as shown above.
`
